### PR TITLE
restore lismore council alerts

### DIFF
--- a/lib/masterview_scraper/authorities.rb
+++ b/lib/masterview_scraper/authorities.rb
@@ -108,7 +108,8 @@ module MasterviewScraper
     lismore: {
       url: "https://tracker.lismore.nsw.gov.au",
       use_api: true,
-      force_detail: true
+      force_detail: true,
+      australian_proxy: true
     },
     port_macquarie_hastings: {
       url: "https://datracker.pmhc.nsw.gov.au",


### PR DESCRIPTION
It appears that Lismore Council have started rejecting connections coming from outside of Australia. 

When I run this locally using an Australian network the scraper runs as expected. I cannot verify that the Australian morph.io proxy will resolve the issue, however as all my local testing shows Australian connections are fine and International connections are rejected i'm assuming it will ;)

